### PR TITLE
Refactor/change lifecycle method in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class SignInScreen extends React.Component {
   };
 
   // Listen to the Firebase Auth state and set the local state.
-  componentWillMount() {
+  componentDidMount() {
     firebase.auth().onAuthStateChanged(
         (user) => this.setState({signedIn: !!user})
     );

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -55,7 +55,7 @@ class App extends React.Component {
   /**
    * @inheritDoc
    */
-  componentWillMount() {
+  componentDidMount() {
     firebaseApp.auth().onAuthStateChanged((user) => {
       this.setState({signedIn: !!user});
     });


### PR DESCRIPTION
Closes #19

Changed `componentWillMount` ➡️`componentDidMount` in these two files:

- [example/src/App.jsx](https://github.com/kristof0425/firebaseui-web-react/blob/refactor/change-lifecycle-method-in-examples/example/src/App.jsx#L58)
- [README.md](https://github.com/kristof0425/firebaseui-web-react/blob/refactor/change-lifecycle-method-in-examples/README.md)