### PR TITLE
Fix uiCallback

### DIFF
--- a/src/FirebaseAuth.jsx
+++ b/src/FirebaseAuth.jsx
@@ -36,6 +36,7 @@ export default class FirebaseAuth extends React.Component {
     this.uiConfig = props.uiConfig;
     this.firebaseAuth = props.firebaseAuth;
     this.className = props.className;
+    this.uiCallback = props.uiCallback;
   }
 
   /**


### PR DESCRIPTION
The `uiCallback` prop wasn't being assigned in the class, causing the if check on line 55 to always be false, rendering the `uiCallback` prop ineffective.