### PR TITLE
Fix typo in example/src/App.jsx

### DIFF
--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -57,7 +57,7 @@ class App extends React.Component {
    */
   componentDidMount() {
     this.unregisterAuthObserver = firebaseApp.auth().onAuthStateChanged(
-        (user) => this.setState({isSignedIn: !!user}
+        (user) => this.setState({isSignedIn: !!user})
     );
   }
 


### PR DESCRIPTION
`(user) => this.setState({isSignedIn: !!user}`
should be
`(user) => this.setState({isSignedIn: !!user})`

In its current form the example fails to build.