### PR TITLE
Fixed potential race condition

### DIFF
--- a/src/FirebaseAuth.jsx
+++ b/src/FirebaseAuth.jsx
@@ -87,10 +87,11 @@ export default class FirebaseAuth extends React.Component {
    * @inheritDoc
    */
   componentWillUnmount() {
-    return firebaseUiDeletion.then(() => {
+    firebaseUiDeletion = firebaseUiDeletion.then(() => {
       this.unregisterAuthObserver();
-      firebaseUiDeletion = this.firebaseUiWidget.delete();
+      return this.firebaseUiWidget.delete();
     });
+    return firebaseUiDeletion;
   }
 
   /**


### PR DESCRIPTION
When I moved away from the login page and was redirected back to the login page, the FirebaseAuth component disappeared. If I did it again, I'd get the error `Uncaught (in promise) Error: AuthUI instance is deleted!` on the following line

https://github.com/firebase/firebaseui-web-react/blob/a9d71ba85765ec03a12624f94eaaef2cba2b8ad0/src/FirebaseAuth.jsx#L92

Using logging, I determined this was because the code in the promise in `componentDidMount()` was running before the code in the promise in `componentWillUnmount()`. To prevent this, I just set `firebaseUiDeletion` outside of promise.