### PR TITLE
Incorrect reference to FirebaseAuth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ FirebaseUI Auth provides a drop-in auth solution that handles the UI flows for s
 
 ## Installation and Usage
 
-> For an example on how to use the FirebaseAuth react component have a look at the [example](./example) folder.
-
 Install the npm package in your React app:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ FirebaseUI Auth provides a drop-in auth solution that handles the UI flows for s
 
 ## Installation and Usage
 
+> For an example on how to use the FirebaseAuth react component have a look at the [example](./example) folder.
+
 Install the npm package in your React app:
 
 ```bash
@@ -82,9 +84,9 @@ class SignInScreen extends React.Component {
 }
 ```
 
-### Using `FirebaseAuth` with local state.
+### Using `StyledFirebaseAuth` with local state.
 
-Below is an example on how to use `FirebaseAuth` with a state change upon sign-in:
+Below is an example on how to use `StyledFirebaseAuth` with a state change upon sign-in:
 
 ```js
 // Import FirebaseAuth and firebase.


### PR DESCRIPTION
I believe this reference to the FirebaseAuth example has been forgotten to be removed from the README following a change that now uses StyledFirebaseAuth in the example only. This is to correct the doc (simply remove the reference).

Would be nice to actually see an example implenentation of FirebaseAuth, though.